### PR TITLE
Create decky-updater.sh

### DIFF
--- a/cli/decky-updater.sh
+++ b/cli/decky-updater.sh
@@ -1,13 +1,13 @@
 #!/bin/sh
 
 #If $1 is set, take that as input
-[[ -n "$1" ]] && release="$1"
+[ -n "$1" ] && release="$1"
 
 #Keep asking which release to install
 while true
 do
     #If $release is set by $1, take that as input
-    [[ -z "$release" ]] && read -p "Install stable or pre-release (s/p): " release
+    [ -z "$release" ] && read -p "Install stable or pre-release (s/p): " release
 
     #Only accept answers with S for stable or P for pre-release
     case $(echo "${release}" | tr '[:lower:]' '[:upper:]') in

--- a/cli/decky-updater.sh
+++ b/cli/decky-updater.sh
@@ -13,12 +13,12 @@ do
     case $(echo "${release}" | tr '[:lower:]' '[:upper:]') in
     S*)
         echo "Installing stable version"
-        # curl -L https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/install_release.sh | sh
+        curl -L https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/install_release.sh | sh
         exit 0
         ;;
     P*)
         echo "Installing pre-release"
-        # curl -L https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/install_prerelease.sh | sh
+        curl -L https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/install_prerelease.sh | sh
         exit 0
         ;;
     *)

--- a/cli/decky-updater.sh
+++ b/cli/decky-updater.sh
@@ -7,7 +7,7 @@
 while true
 do
     #If $release is set by $1, take that as input
-    [ -z "$release" ] && read -p "Install stable or pre-release (s/p): " release
+    [ -z "$release" ] && read -p "Install stable/pre-release or uninstall (s/p/u): " release
 
     #Only accept answers with S for stable or P for pre-release
     case $(echo "${release}" | tr '[:lower:]' '[:upper:]') in
@@ -19,6 +19,11 @@ do
     P*)
         echo "Installing pre-release"
         curl -L https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/install_prerelease.sh | sh
+        exit 0
+        ;;
+    U*)
+        echo "Uninstalling decky"
+        curl -L https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/uninstall.sh | sh
         exit 0
         ;;
     *)

--- a/cli/decky-updater.sh
+++ b/cli/decky-updater.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+#If $1 is set, take that as input
+[[ -n "$1" ]] && release="$1"
+
+#Keep asking which release to install
+while true
+do
+    #If $release is set by $1, take that as input
+    [[ -z "$release" ]] && read -p "Install stable or pre-release (s/p): " release
+
+    #Only accept answers with S for stable or P for pre-release
+    case $(echo "${release}" | tr '[:lower:]' '[:upper:]') in
+    S*)
+        echo "Installing stable version"
+        # curl -L https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/install_release.sh | sh
+        exit 0
+        ;;
+    P*)
+        echo "Installing pre-release"
+        # curl -L https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/install_prerelease.sh | sh
+        exit 0
+        ;;
+    *)
+        unset release
+        continue
+        ;;
+    esac
+done


### PR DESCRIPTION
This is an interactive script to install or update decky-loader.

I wrote this script since decky-loader often can't be updated easily through the menu after it is broken by a SteamOS update. Not entirely necessary, but I personally prefer to run an existing script that I have installed rather than using curl to run a specific script. Not sure the best way to obtain this specific script the first time in a way that is easy for the Steam Deck crowd, besides pulling it along with decky-loader, but its something I wanted to put out there anyway.