### PR TITLE
Fix broken command when enabling debugging for flatpak

### DIFF
--- a/cli/install_release.sh
+++ b/cli/install_release.sh
@@ -28,7 +28,7 @@ sudo -u $SUDO_USER mkdir -p "${HOMEBREW_FOLDER}/services"
 sudo -u $SUDO_USER mkdir -p "${HOMEBREW_FOLDER}/plugins"
 sudo -u $SUDO_USER touch "${USER_DIR}/.steam/steam/.cef-enable-remote-debugging"
 # if installed as flatpak, put .cef-enable-remote-debugging there
-[ -d "${USER_DIR}/.var/app/com.valvesoftware.Steam/data/Steam/" ] && sudo -u "$SUDO_USER touch ${USER_DIR}/.var/app/com.valvesoftware.Steam/data/Steam/.cef-enable-remote-debugging"
+[ -d "${USER_DIR}/.var/app/com.valvesoftware.Steam/data/Steam/" ] && sudo -u $SUDO_USER touch "${USER_DIR}/.var/app/com.valvesoftware.Steam/data/Steam/.cef-enable-remote-debugging"
 
 # Download latest release and install it
 RELEASE=$(curl -s 'https://api.github.com/repos/SteamDeckHomebrew/decky-loader/releases' | jq -r "first(.[] | select(.prerelease == "false"))")


### PR DESCRIPTION
The `.cef-enable-remote-debugging` file was not being created in the flatpak directory because of an incorrect command. 

It was showing this:
```
sudo: touch /home/$USER/.var/app/com.valvesoftware.Steam/data/Steam/.cef-enable-remote-debugging: command not found
```

The prerelease installer works fine though.