### PR TITLE
Do a connectivity check for Github Api

### DIFF
--- a/cli/install_prerelease.sh
+++ b/cli/install_prerelease.sh
@@ -17,6 +17,13 @@ then
     exit 1
 fi
 
+# check if api.github.com is working(not rate-limited)
+if ! curl -Is https://api.github.com/repos/SteamDeckHomebrew/decky-loader/releases | head -1 | grep 200 > /dev/null
+then
+    echo "Your network are being rate-limited from Github api, please wait for a while and try again."
+    exit 1
+fi
+
 echo "Installing Steam Deck Plugin Loader pre-release..."
 
 USER_DIR="$(getent passwd $SUDO_USER | cut -d: -f6)"

--- a/cli/install_prerelease.sh
+++ b/cli/install_prerelease.sh
@@ -20,7 +20,7 @@ fi
 # check if api.github.com is working(not rate-limited)
 if ! curl -Is https://api.github.com/repos/SteamDeckHomebrew/decky-loader/releases | head -1 | grep 200 > /dev/null
 then
-    echo "Your network are being rate-limited from Github api, please wait for a while and try again."
+    echo "Your network have problems accessing Github Api(probably rate-limited), please wait for a while and try again."
     exit 1
 fi
 

--- a/cli/install_release.sh
+++ b/cli/install_release.sh
@@ -20,7 +20,7 @@ fi
 # check if api.github.com is working(not rate-limited)
 if ! curl -Is https://api.github.com/repos/SteamDeckHomebrew/decky-loader/releases | head -1 | grep 200 > /dev/null
 then
-    echo "Your network are being rate-limited from Github api, please wait for a while and try again."
+    echo "Your network have problems accessing Github Api(probably rate-limited), please wait for a while and try again."
     exit 1
 fi
 

--- a/cli/install_release.sh
+++ b/cli/install_release.sh
@@ -17,6 +17,13 @@ then
     exit 1
 fi
 
+# check if api.github.com is working(not rate-limited)
+if ! curl -Is https://api.github.com/repos/SteamDeckHomebrew/decky-loader/releases | head -1 | grep 200 > /dev/null
+then
+    echo "Your network are being rate-limited from Github api, please wait for a while and try again."
+    exit 1
+fi
+
 echo "Installing Steam Deck Plugin Loader release..."
 
 USER_DIR="$(getent passwd $SUDO_USER | cut -d: -f6)"


### PR DESCRIPTION
Just like the github.com reachable check, if api.github.com fails to connect for some reason(bad dns, rate-limit, etc), the installer would jump-out instead of continue running and cause lots of errors(and even return success installation).

p.s : does not consider the situation that this will be the last request before rate-limited (so it still fail when installing),but most time should be fine(e.g you are already rate-limited).